### PR TITLE
fix typo in flowFdaClasses

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.Rproj
+.Rproj.user/

--- a/R/flowFdaClasses.R
+++ b/R/flowFdaClasses.R
@@ -49,7 +49,7 @@ rm(hlp,prcompProt,mclustProt)
 #' @exportClass flowBasis
 #' 
 
-setClass("flowBasis",representation(basis="matrix",param="matrix",pcom="matrix",nbin="integer",bw="numeric",probBin="logical",fset="flowSet",fmod="flowFPModel",fp="flowFP"),prototype = list(basis=matrix(nrow=0,ncol=0),para=matrix(ncol=2,nrow=0),pcom=matrix(ncol=2,nrow=0),nbin=integer(),bw=numeric(),probBin=logical(),fset=new(Class="flowSet"),fmod=new(Class="flowFPModel"),fp=new(Class="flowFP")))
+setClass("flowBasis",representation(basis="matrix",param="matrix",pcom="matrix",nbin="integer",bw="numeric",probBin="logical",fset="flowSet",fmod="flowFPModel",fp="flowFP"),prototype = list(basis=matrix(nrow=0,ncol=0),param=matrix(ncol=2,nrow=0),pcom=matrix(ncol=2,nrow=0),nbin=integer(),bw=numeric(),probBin=logical(),fset=new(Class="flowSet"),fmod=new(Class="flowFPModel"),fp=new(Class="flowFP")))
 
 #' The flowPca class
 #' 

--- a/R/flowFdaClasses.R
+++ b/R/flowFdaClasses.R
@@ -1,5 +1,5 @@
 ###
-#use S3 classes prcomp and Mclust as S4 slots 
+#use S3 classes prcomp and Mclust as S4 slots
 #prcomp constructor
 hlp<-rnorm(100)
 dim(hlp)<-c(10,10)
@@ -8,17 +8,17 @@ prcompProt=prcomp(hlp)
 for (i in (1:length(prcompProt)))
 prcompProt[[i]]=new(Class=class(prcompProt[[i]]))
 
-mclustProt=Mclust(hlp)
+mclustProt = Mclust(hlp)
 for (i in (1:length(mclustProt)))
 {
-className=class(mclustProt[[i]])
-mclustProt[[i]]=try(new(Class=class(mclustProt[[i]])),silent=TRUE)
-if (class(mclustProt[[i]])=="try-error") 
-{	
-#mclustProt[[i]]=NULL	
-mclustProt[[i]]= "not initialized"
-class(mclustProt[[i]])=className
-}
+  className = class(mclustProt[[i]])
+  mclustProt[[i]] = try(new(Class = class(mclustProt[[i]])), silent = TRUE)
+  if (inherits(mclustProt[[i]],"try-error"))
+  {
+    #mclustProt[[i]]=NULL
+    mclustProt[[i]] = "not initialized"
+    class(mclustProt[[i]]) = className
+  }
 }
 
 setOldClass("prcomp",prototype=prcompProt)
@@ -28,10 +28,10 @@ rm(hlp,prcompProt,mclustProt)
 
 # S4 documentation using Roxygen.
 #' The flowBasis class
-#' 
+#'
 #' This class represents a flowset by a basis derived from a kernel density estimator using an equally spaced grid.
 #'
-#' @section Slots: 
+#' @section Slots:
 #' \describe{
 #'  \item{\code{basis}:}{A matrix with the basis coefficients}
 #'  \item{\code{pcom}:}{A matrix with the channel combinations for which bivariate densities are calculated}
@@ -43,19 +43,19 @@ rm(hlp,prcompProt,mclustProt)
 #' \item{\code{fmod}:}{flowFPModel used when probBin=TRUE. If probBin is FALSE the model is empty and the improved approach is adopted.  Probability binning is provided for compatibility with De Roy et al. (2012).}
 #' \item{\code{fp}:}{flowFP fingerprint used when probBin=TRUE. If probBin is FALSE the fp object is empty and the improved approach is adopted.  Probability binning is provided for compatibility with De Roy et al. (2012).}
 #' }
-#' @references De Roy, K., Clement, L., Thas, O., Wang, Y., and Boon, N. (2012). Flow cytometry for fast microbial community fingerprinting. Water Research, 46 (3), 907-919. 
+#' @references De Roy, K., Clement, L., Thas, O., Wang, Y., and Boon, N. (2012). Flow cytometry for fast microbial community fingerprinting. Water Research, 46 (3), 907-919.
 #' @name flowBasis-class
 #' @rdname flowBasis-class
 #' @exportClass flowBasis
-#' 
+#'
 
 setClass("flowBasis",representation(basis="matrix",param="matrix",pcom="matrix",nbin="integer",bw="numeric",probBin="logical",fset="flowSet",fmod="flowFPModel",fp="flowFP"),prototype = list(basis=matrix(nrow=0,ncol=0),param=matrix(ncol=2,nrow=0),pcom=matrix(ncol=2,nrow=0),nbin=integer(),bw=numeric(),probBin=logical(),fset=new(Class="flowSet"),fmod=new(Class="flowFPModel"),fp=new(Class="flowFP")))
 
 #' The flowPca class
-#' 
+#'
 #' This class represents a principal component basis derived from a flowBasis-class object
 #'
-#' @section Slots: 
+#' @section Slots:
 #'  \describe{
 #'  \item{\code{pcaObj}:}{A stats::prcomp object with output form the principal component analysis using the function prcomp}
 #'  \item{\code{pcom}:}{A matrix with the channel combinations for which bivariate densities are calculated in the flowBasis object}
@@ -66,17 +66,17 @@ setClass("flowBasis",representation(basis="matrix",param="matrix",pcom="matrix",
 #' \item{\code{nPca}:}{An integer with the number of principal components that are used in model based clustering, empty if no clustering has been done yet}
 #' \item{\code{probBin}:}{Logical flag to indicate if probability binning of flowFP is used for construction of basis. Probability binning is provided for compatibility with De Roy et al. (2012).}
 #' }
-#' @references De Roy, K., Clement, L., Thas, O., Wang, Y., and Boon, N. (2012). Flow cytometry for fast microbial community fingerprinting. Water Research, 46 (3), 907-919. 
+#' @references De Roy, K., Clement, L., Thas, O., Wang, Y., and Boon, N. (2012). Flow cytometry for fast microbial community fingerprinting. Water Research, 46 (3), 907-919.
 #' @name flowPca-class
 #' @rdname flowPca-class
 #' @exportClass flowPca
 setClass("flowPca",representation(pcaObj="prcomp",param="matrix",pcom="matrix",nbin="integer",bw="numeric",clust="Mclust",nPca="numeric",probBin="logical"),prototype=list(pcaObj=new(Class="prcomp"),param=matrix(ncol=2,nrow=0),pcom=matrix(ncol=2,nrow=0),nbin=integer(),bw=numeric(),clust=new(Class="Mclust"),nPca=numeric(),probBin=logical()))
 
 #' The flowDa class
-#' 
+#'
 #' This class extends the flowPca class by constructing a Fisher Discriminant Analysis using Fisher's Method
-#' 
-#' @section Slots: 
+#'
+#' @section Slots:
 #'  \describe{
 #'  \item{\code{daObj}:}{A list with the output from the Fisher Discriminant Analysis (FDA)}
 #'  \item{\code{groups}:}{A factor object with the class labels for each sample}
@@ -89,7 +89,7 @@ setClass("flowPca",representation(pcaObj="prcomp",param="matrix",pcom="matrix",n
 #' \item{\code{bw}:}{The bandwith for the kernel density estimator used to construct the flowBasis object}
 #' \item{\code{probBin}:}{Logical flag to indicate if probability binning of flowFP is used for construction of basis. Probability binning is provided for compatibility with De Roy et al. (2012).}
 #' }
-#' @references De Roy, K., Clement, L., Thas, O., Wang, Y., and Boon, N. (2012). Flow cytometry for fast microbial community fingerprinting. Water Research, 46 (3), 907-919. 
+#' @references De Roy, K., Clement, L., Thas, O., Wang, Y., and Boon, N. (2012). Flow cytometry for fast microbial community fingerprinting. Water Research, 46 (3), 907-919.
 #' @name flowDa-class
 #' @rdname flowDa-class
 #' @exportClass flowDa

--- a/vignettes/flowFDA.Rnw
+++ b/vignettes/flowFDA.Rnw
@@ -1,7 +1,7 @@
 \documentclass[10pt]{article}
 %\VignetteIndexEntry{Using flowFDA}
 %\VignetteIndexEntry{flowFDA}
- 
+
 
  \usepackage{graphicx}
   \usepackage{subfigure}
@@ -21,7 +21,6 @@
  \usepackage{color}
 \usepackage{epstopdf}
  \usepackage{Sweave}
-   \usepackage[utf8x]{inputenc} 
 \parskip 0.4cm
 \parindent 0cm
 
@@ -55,7 +54,7 @@
 \newcommand{\bsigma}{\mb{\Sigma}}
 \newcommand{\btheta}{\mb{\theta}}
 \newcommand{\bEta}{\mb{\eta}}
-\newcommand{\bbeta}{\mb{\beta}} 
+\newcommand{\bbeta}{\mb{\beta}}
 \newcommand{\balpha}{\mb{\alpha}}
 \newcommand{\bgamma}{\mb{\gamma}}
 \newcommand{\bphi}{\mb{\varphi}}
@@ -68,7 +67,7 @@
 \newcommand{\logit}{\mathrm{logit}}
 \newcommand{\cH}{\mathcal{H}}
 \newcommand{\odds}[1]{\mathrm{odds}\left( #1 \right)}
-%\DeclareMathOperator*{\min}{min} 
+%\DeclareMathOperator*{\min}{min}
 
 
 
@@ -86,15 +85,15 @@
 \tableofcontents
 
 \section{Introduction}
-The \texttt{flowFDA} package can be used for analysing flow cytometry (FC) experiments with functional model based clustering, functional principal component analysis, functional discriminant analysis and to compare multivariate flowcytometry fingerprints across treatments. 
+The \texttt{flowFDA} package can be used for analysing flow cytometry (FC) experiments with functional model based clustering, functional principal component analysis, functional discriminant analysis and to compare multivariate flowcytometry fingerprints across treatments.
 
 Flow cytometry (FC) can generate fast fingerprints by characterizing the multivariate distribution of cellular features of single cells. We developed a statistical pipeline for classifying samples and for inferring on distributional changes induced by experimental factors. Our method consists of 1) Creating a quantitative fingerprint from the multivariate distribution, 2) Extracting informative fingerprint features by discriminant analysis, 3) Permutation tests for assessing differences across treatment groups in the reduced feature space and 4) Interpreting these differences in terms of changes in the multivariate FC distribution. We illustrate our method on a case study, which aims at detecting changes in microbial community composition of drinking water induced by environmental stress.
 
-The example data used in this vignette are a subset of the data provided by De Roy et al. (2012). It contains a flowset of n=30 different flows for the stress experiment. Two types of treatments were conducted on Evian water to simulate changing physico- chemical conditions: temperature and nutrient treatment. For the heat treatment, 1 L bottles were incubated for 3 and 24 h at 37 degrees Celsius. For the nutrient treatment, 1 mL of water was replaced by 1 mL of a 1/10 dilution of autoclaved Luria-Bertani broth (10 g tryptone, 5 g yeast extract and 10 g NaCl per L) to a final TOC of 0.65 mg/L. The bottles were incubated for 3 and 24 h at room temperature. The five treatments are coded as follows: control (c), 3h heat treatment (h3), 24h heat treatment (h24), 3h nutrient treatment (n3) and 24h nutrient treatment (n24). Two fluorescent dyes, SYBR Green and Propidium Iodide, were used in combination as a viability indicator. The channels SS Log, FL 1 Log and FL 3 Log are used in the vignette, which correspond to the bandwidth filters for the side scatter and the staining. 
+The example data used in this vignette are a subset of the data provided by De Roy et al. (2012). It contains a flowset of n=30 different flows for the stress experiment. Two types of treatments were conducted on Evian water to simulate changing physico- chemical conditions: temperature and nutrient treatment. For the heat treatment, 1 L bottles were incubated for 3 and 24 h at 37 degrees Celsius. For the nutrient treatment, 1 mL of water was replaced by 1 mL of a 1/10 dilution of autoclaved Luria-Bertani broth (10 g tryptone, 5 g yeast extract and 10 g NaCl per L) to a final TOC of 0.65 mg/L. The bottles were incubated for 3 and 24 h at room temperature. The five treatments are coded as follows: control (c), 3h heat treatment (h3), 24h heat treatment (h24), 3h nutrient treatment (n3) and 24h nutrient treatment (n24). Two fluorescent dyes, SYBR Green and Propidium Iodide, were used in combination as a viability indicator. The channels SS Log, FL 1 Log and FL 3 Log are used in the vignette, which correspond to the bandwidth filters for the side scatter and the staining.
 
-\section{Importing Data} 
+\section{Importing Data}
 
-The package builds upon the \texttt{flowCore} package to import raw flow cytometric data files in R (Ellis et al., 2013). 
+The package builds upon the \texttt{flowCore} package to import raw flow cytometric data files in R (Ellis et al., 2013).
 We first have to load the \texttt{flowFDA} package and read the flowset. The \texttt{read.flowSet()} function will read all fcs files in the directory specified in \texttt{path} argument. In our pipeline, informative file names are used, i.e. treatmentx\_replicatey.fcs.  This accommodates a straightforward automation of the data analysis workflow. Users that want to import their own FC experiments can modify the commented code below.
 <<>>=
 library(flowFDA)
@@ -106,9 +105,9 @@ library(flowFDA)
 #param=c("SS Log","FL 1 Log","FL 3 Log")
 #fset=fset[,param]
 #fset
-@ 
+@
 
-We will use the channels SS Log, FL 1 Log and FL 3 Log, which correspond to the side scatter, SYBR green and Propidium Iodide staining bandpass filters. The data have been transformed to fall within a range of 0 and 1 and extremely low intensities are removed using a rectangular gate so as to avoid artefacts. The flowcytometer used in this study returned log transformed intensities and had a maximum log transformed intensity of $2^{16}$. 
+We will use the channels SS Log, FL 1 Log and FL 3 Log, which correspond to the side scatter, SYBR green and Propidium Iodide staining bandpass filters. The data have been transformed to fall within a range of 0 and 1 and extremely low intensities are removed using a rectangular gate so as to avoid artefacts. The flowcytometer used in this study returned log transformed intensities and had a maximum log transformed intensity of $2^{16}$.
 <<>>=
 #mytrans<-function(x) x/2^16
 #fset<-transform("FL 1 Log"=mytrans,"FL 3 Log"=mytrans,"SS Log"=mytrans)%on%fset
@@ -120,20 +119,20 @@ We will use the channels SS Log, FL 1 Log and FL 3 Log, which correspond to the 
 <<>>=
 #logtrans<- function(x) log(x)
 @
- 
+
 A good choice of the filename can enable an automated construction of the grouping variable
 <<>>=
-#construct experiment factor 
+#construct experiment factor
 #files<-list.files(path="~/Dropbox/LabMet/flowcytometry/stress_test_2/",pattern=".fcs")
-#expHlp<-unlist(strsplit(files,split="_replicate")) 
+#expHlp<-unlist(strsplit(files,split="_replicate"))
 #dim(expHlp)<-c(2,length(fset))
 #group<-as.factor(expHlp[1,])
 #nGroup<-nlevels(group)
 @
 
 
-The steps above have been performed on the example data. 
-The data has not been integrated in the \texttt{flowFDA} package to comply with the Bioconductor guidelines with regard to the size of software packages. 
+The steps above have been performed on the example data.
+The data has not been integrated in the \texttt{flowFDA} package to comply with the Bioconductor guidelines with regard to the size of software packages.
 The example dataset can be found in the \texttt{flowFDAExampleData}data package and that can be downloaded from github.
 
 <<CompanionPkg, eval=FALSE>>=
@@ -157,24 +156,24 @@ groupLevels=levels(group)
 @
 
 \section{Fingerprinting: constructing flowBasis object}
-A \texttt{flowBasis} object contains fingerprints of the multivariate flow cytometry (FC) distributions of the $N$ different samples in the study. 
+A \texttt{flowBasis} object contains fingerprints of the multivariate flow cytometry (FC) distributions of the $N$ different samples in the study.
 The package default constructs a fingerprint using all $q=(n_\text{channel})\times(n_\text{channel}+1)/2$ pairwise bivariate densities of the $n_\text{channel}$ flow channels of interest.
-{Each bivariate density is estimated using a kernel density estimator with bandwidth bw. 
+{Each bivariate density is estimated using a kernel density estimator with bandwidth bw.
 Next, functional data analysis in the \texttt{flowFDA} package is provided by a discretisation approach: i.e. the kernel density estimators are used to calculate smoothed density estimates on an equally spaced mesh with  $n_\text{bin} \times n_\text{bin}$ grid points.
-This yields an $N \times r$ data matrix $\mb{X}$ (with $r=q\times n_\text{bin}^2$) that can be processed with standard multivariate data analysis methods (e.g. Ramsay and Silverman, 2005).  
-The rows of the matrix $\mb{X}$ are referred to as the fingerprints.  
-The fingerprints thus provide a straightforward graphical interpretation in terms of the bivariate distributions of flow channels. 
+This yields an $N \times r$ data matrix $\mb{X}$ (with $r=q\times n_\text{bin}^2$) that can be processed with standard multivariate data analysis methods (e.g. Ramsay and Silverman, 2005).
+The rows of the matrix $\mb{X}$ are referred to as the fingerprints.
+The fingerprints thus provide a straightforward graphical interpretation in terms of the bivariate distributions of flow channels.
 }
 <<>>=
 fbasis=flowBasis(fset,param,nbin=128, bw=0.01)
 fbasis
 @
-Similar to De Roy et al. (2012), one might also use probability binning (PB) for fingerprinting. 
-Details are provided in the \texttt{flowFDAProbabilityBinning} vignette. 
-However, interpretation based on plots using PB is less convenient. 
+Similar to De Roy et al. (2012), one might also use probability binning (PB) for fingerprinting.
+Details are provided in the \texttt{flowFDAProbabilityBinning} vignette.
+However, interpretation based on plots using PB is less convenient.
 
 \section{Data exploration}
-The bivariate densities can be explored graphically. An example for the third flowset can be generated using the code below. The plot for the kernel density basis is given in Figure \ref{figFbasis3}. 
+The bivariate densities can be explored graphically. An example for the third flowset can be generated using the code below. The plot for the kernel density basis is given in Figure \ref{figFbasis3}.
 \begin{figure}[h!]
 \begin{center}
 <<fig=TRUE, png=TRUE, pdf=FALSE, eps=FALSE>>=
@@ -186,7 +185,7 @@ plot(fbasis,ask=FALSE,samples=3)
 \label{figFbasis3}
 \end{figure}
 \clearpage
-The fingerprints can also be averaged over several flows, e.g. for the flows belonging to the same group. An example of the graphical interpretation of the averaged fingerprint for the control group (c) and 24h nutrient treatment group (n24) are given in Figure \ref{figFbasisCN24h}. The cells for the c-group are more tightly centered around a SS of .35, FL1 of .5 and a FL3 of 0.3. For the n24-group the distribution has a larger variance and includes a considerable number of cells at higher SS, FL1 and FL3 values. This region corresponds to larger cells with more nucleic acids and intact membranes. 
+The fingerprints can also be averaged over several flows, e.g. for the flows belonging to the same group. An example of the graphical interpretation of the averaged fingerprint for the control group (c) and 24h nutrient treatment group (n24) are given in Figure \ref{figFbasisCN24h}. The cells for the c-group are more tightly centered around a SS of .35, FL1 of .5 and a FL3 of 0.3. For the n24-group the distribution has a larger variance and includes a considerable number of cells at higher SS, FL1 and FL3 values. This region corresponds to larger cells with more nucleic acids and intact membranes.
 \begin{figure}[h!]
 \begin{center}
 <<fig=TRUE, png=TRUE, pdf=FALSE, eps=FALSE>>=
@@ -216,21 +215,21 @@ contour=TRUE,contourLwd=4,contourLevel=c(-.04,.04))
 \label{figFbasisContrast}
 \end{figure}
 \clearpage
-The fingerprints can also be explored by using principal component analysis and model based clustering. 
-Principal component analysis (PCA) is often used for dimension reduction. 
-The fingerprint matrix $\mb{X}$ can be fed into the standard multivariate principal components analysis routine \texttt{prcomp}. 
-It performs a rotation of the centered input variables without loss of information and essentially provides a decomposition of the variance-covariance matrix of $\mb{X}$. 
-We establish dimension reduction by retaining the $p$ principal components (PC's) so that portion of the variance that is explained by them exceeds a certain threshold $\delta$. 
+The fingerprints can also be explored by using principal component analysis and model based clustering.
+Principal component analysis (PCA) is often used for dimension reduction.
+The fingerprint matrix $\mb{X}$ can be fed into the standard multivariate principal components analysis routine \texttt{prcomp}.
+It performs a rotation of the centered input variables without loss of information and essentially provides a decomposition of the variance-covariance matrix of $\mb{X}$.
+We establish dimension reduction by retaining the $p$ principal components (PC's) so that portion of the variance that is explained by them exceeds a certain threshold $\delta$.
 {As PC's consist of linear combinations of input variables, the PC loadings $\mb{M}$ and scores $\mb{S}$ can be interpreted in terms of the original pairwise bivariate FC densities.}
- Hence, we can explore the FC data using a low dimensional representation, while still enabling interpretation with respect to features measured in the different FC channels. 
+ Hence, we can explore the FC data using a low dimensional representation, while still enabling interpretation with respect to features measured in the different FC channels.
 
-For model based clustering we build upon the \texttt{mclust} package that adopts Gaussian mixture models. 
-Model based clustering in this example is performed by using the first 6 principal components. They capture more than 95\% of the variability in the original fingerprints. Scores on the first 2 principal components are given in Figure \ref{figPCAbiplot}. 
+For model based clustering we build upon the \texttt{mclust} package that adopts Gaussian mixture models.
+Model based clustering in this example is performed by using the first 6 principal components. They capture more than 95\% of the variability in the original fingerprints. Scores on the first 2 principal components are given in Figure \ref{figPCAbiplot}.
 <<>>=
 #construct flowPca object
-fPca=flowPca(fbasis) 
+fPca=flowPca(fbasis)
 
-#perform model based clustering, 
+#perform model based clustering,
 #use n PCs so as to capture at least 95 % of the variability
 nPca(fPca)<-.95
 nPca(fPca) #number of PCs used for model based clustering
@@ -241,9 +240,9 @@ cbind(as.character(getClustClass(fPca)),as.character(group)) # cluster class lab
 \begin{center}
 <<fig=TRUE, png=TRUE, pdf=FALSE, eps=FALSE>>=
 par(mfrow=c(1,2))
-plot(fPca,groups=getClustClass(fPca),main="Kernel Dens. (Clustering)") 
+plot(fPca,groups=getClustClass(fPca),main="Kernel Dens. (Clustering)")
 plot(fPca,groups=group,main="Kernel Dens. (Treatment)")
-legend("topleft",legend=c("c","h24","h3","n24","n3"),pch=1:5,col=1:5) 
+legend("topleft",legend=c("c","h24","h3","n24","n3"),pch=1:5,col=1:5)
 @
 \end{center}
 \caption{Scores for the first two principal components. In the left panel the samples are classified using model based clustering and in the right panel the samples are labelled according to the actual experimental factor.}
@@ -251,21 +250,21 @@ legend("topleft",legend=c("c","h24","h3","n24","n3"),pch=1:5,col=1:5)
 \end{figure}
 \clearpage
 
-The classification with model based clustering provides a considerable resemblance to the real grouping, indicating that main features in the distribution of the size and staining characteristics are affected by the treatment. The separation between 24h heat treatment (h24) and the control (c) treatment in the PC1 and PC2 space indicates that the distributions for the c- and h24-treatment are more similar than the distributions for the flows of other treatments. 
+The classification with model based clustering provides a considerable resemblance to the real grouping, indicating that main features in the distribution of the size and staining characteristics are affected by the treatment. The separation between 24h heat treatment (h24) and the control (c) treatment in the PC1 and PC2 space indicates that the distributions for the c- and h24-treatment are more similar than the distributions for the flows of other treatments.
 
-{The scores $\mb{S}$ on the PC's can be interpreted in terms of the original bivariate distributions. 
+{The scores $\mb{S}$ on the PC's can be interpreted in terms of the original bivariate distributions.
 They consist of linear combinations of the centered fingerprint, the contrast between the sample and average fingerprint over all samples.
-\[\mb{S}=\mb{X}^*\mb{M},\] with $\mb{X}^*=\mb{X}-\mb{1}\bar{\mb{X}}^T$ the matrix with the centered fingerprint and $\mb{M}$ the loading matrix. 
+\[\mb{S}=\mb{X}^*\mb{M},\] with $\mb{X}^*=\mb{X}-\mb{1}\bar{\mb{X}}^T$ the matrix with the centered fingerprint and $\mb{M}$ the loading matrix.
 Some of the $j=1,\ldots,r$ centered fingerprint grid points $x_{ij}^*$ of sample $i$ will contribute negatively to the $k^\text{th}$ PC score, $s_{ik},$ and others positively.
 The colours in the plot indicates this contribution: $s_{ijk}=x_{ij}^*m_{jk}$.
-Hence, the score $s_{ik}$ on the $k^\text{th}$ component consists of the sum over all $n_\text{bin}\times n_\text{bin}$ grid points in all $q$ bivariate combinations of the flow channels of interest, i.e. $s_{ik}=\sum_{j=1}^r x_{ij}^*m_{jk}$. 
-Contours are also added to the interpretation plot. 
+Hence, the score $s_{ik}$ on the $k^\text{th}$ component consists of the sum over all $n_\text{bin}\times n_\text{bin}$ grid points in all $q$ bivariate combinations of the flow channels of interest, i.e. $s_{ik}=\sum_{j=1}^r x_{ij}^*m_{jk}$.
+Contours are also added to the interpretation plot.
 They indicate appropriate contrasts in the original fingerprints. }
 
 {The interpretation of the score for sample 3 is given in the caption of Figure \ref{figPCAbiplotInt}.
 Because we are assessing one sample, the contours represent the contrast between the sample 3 and the average fingerprint, i.e. the centered fingerprint for sample 3.  The contours show if the bivariate kernel density estimate on the grid point is denser (red, ``+'') or less dens (blue, ``-'') than the averaged bivariate density estimates over all samples. }
 
-{Similar plots can be constructed for contrasts in the PCA space. 
+{Similar plots can be constructed for contrasts in the PCA space.
 Then the colours will represent the contribution to the contrast on a particular PC and the contours will be constructed for contrasts in centered fingerprints. More details on contrasts are provided in the section on discriminant analysis.
 }
 
@@ -283,7 +282,7 @@ arrows(x0=pcX,x1=pcX,y0=-2,y1=pcY)
  # interpretation in terms of contrast to average bivariate density
  #contrast between average bivariate density of intSamples vs overall average
 L=rep(-1/nSamp,nSamp)
-L[intSamples]=L[intSamples]+1/length(intSamples) 
+L[intSamples]=L[intSamples]+1/length(intSamples)
 
 plot(fPca,fBasis=fbasis,disc=1,plotType="pcaCont",L=L,ask=FALSE,main="PC 1",contour=TRUE,contourLwd=3,contourLevel=c(-.04,.04))
 @
@@ -296,17 +295,17 @@ plot(fPca,fBasis=fbasis,disc=1,plotType="pcaCont",L=L,ask=FALSE,main="PC 1",cont
 
 \section{Discriminant Analysis and Classification}
 Discriminant analysis (DA) aims at understanding how $K-$groups differ from one another in terms of the $p-$dimensional FC fingerprint. We adopt Fisher DA, which does not impose distributional assumptions and interprets the difference among the $K-$groups by projecting the input variables onto discriminants. In one dimension a good discrimination is obtained when the between class variance of the $K$ experimental groups is large compared to their within class variance. The discriminants are the linear combinations of input variables that maximize the between class variance with respect to the within class variance after projecting the data onto the particular discriminant. It can be shown that $K$ groups in the $r-$dimensional fingerprint feature space span at most a $K-1$ dimensional subspace of orthogonal discriminants. Hence, a huge dimension reduction occurs when $K << r$. Quantitative measures exist for the relative potential of the k-th discriminant function to discriminate the $K-$groups. They are often used for deciding the number of discriminants that are required for a good discrimination between groups and can provide a further dimension reduction. Because discriminants are linear combinations of the input variables, they often provide a very useful interpretation within the original data space. We will use this property for displaying the leading differences in the pairwise bivariate distributions of the FC profiles.
-If Fisher discriminant analysis (DA) is performed on the original basis, a perfect discrimination will be obtained because we have much more features than observations. Hence, the optimal solution is located in the null space. We provide regularisation of the within group covariance matrix by performing PCA on the fingerprint first and adopting DA on the first $p$ PC's.  
-Note, that PCA is commonly used for regularizing matrix inverses, e.g. in principal component regression to deal with multicollinearity in a linear modelling context, and, that the use of all PC's in the DA would provide the same solution as the DA on all fingerprint features. 
+If Fisher discriminant analysis (DA) is performed on the original basis, a perfect discrimination will be obtained because we have much more features than observations. Hence, the optimal solution is located in the null space. We provide regularisation of the within group covariance matrix by performing PCA on the fingerprint first and adopting DA on the first $p$ PC's.
+Note, that PCA is commonly used for regularizing matrix inverses, e.g. in principal component regression to deal with multicollinearity in a linear modelling context, and, that the use of all PC's in the DA would provide the same solution as the DA on all fingerprint features.
 
-We suggest to use the first few PC's that explain more that 95\%  of the variability in the fingerprint. This can be done by setting \texttt{nPca=0.95} when calling the \texttt{flowDa} constructor. In our application this corresponds to 6 PCs. Hence, we reduced the dimensionality of the problem from $3\times128\times128$ fingerprint features to 6. 
+We suggest to use the first few PC's that explain more that 95\%  of the variability in the fingerprint. This can be done by setting \texttt{nPca=0.95} when calling the \texttt{flowDa} constructor. In our application this corresponds to 6 PCs. Hence, we reduced the dimensionality of the problem from $3\times128\times128$ fingerprint features to 6.
 
 Since we perform PCA first, the \texttt{flowDa} object inherits all properties of a \texttt{flowPca} object and all plots from the previous section can be constructed using a \texttt{flowDa} object.
 <<>>=
 #supervised, class labels are needed
-#select first few PC's which explain more than 95% of the variability in the original fingerprint. 
+#select first few PC's which explain more than 95% of the variability in the original fingerprint.
 #####Discriminant analysis for kernel dens.
-fDa=flowDa(fbasis,groups= group, nPca=.95) 
+fDa=flowDa(fbasis,groups= group, nPca=.95)
 fDa
 @
 
@@ -327,8 +326,8 @@ legend("bottomleft",legend=c("c","h24","h3","n24","n3"),pch=1:5,col=1:5)
 
 
 \section{Test for differences in the discriminant space}
-Statistical hypothesis tests can be performed after dimension reduction. Pairwise tests in the discriminant space are adopted for assessing significance of observed differences between the groups. Standard procedures implemented in \texttt{p.adjust()} can be used to address the problem of multiple hypothesis testing. 
-Because the data was already used within the dimension reduction procedure, standard statistical hypothesis testing in the discriminant space does not control the type I error at the nominal significance level, $\alpha=0.05$. 
+Statistical hypothesis tests can be performed after dimension reduction. Pairwise tests in the discriminant space are adopted for assessing significance of observed differences between the groups. Standard procedures implemented in \texttt{p.adjust()} can be used to address the problem of multiple hypothesis testing.
+Because the data was already used within the dimension reduction procedure, standard statistical hypothesis testing in the discriminant space does not control the type I error at the nominal significance level, $\alpha=0.05$.
 We adopt permutation-based procedures for deriving the null distribution of the test statistics. The following procedure is proposed:
 \begin{enumerate}
 \item Permute class labels,
@@ -339,10 +338,10 @@ $t^*$ within the discriminant space of 2,
 \end{enumerate}
 Permutation-based p-values are then defined as the fraction of the permuted test statistics that are more extreme than the observed test statistic: \[p=\frac{\#[\vert t^*\vert>\vert t \vert]}{B}\].
 
-Permutation tests are performed on each discriminant separately so as to retain the interpretation feature: i.e. significant tests can be interpreted in terms of the original fingerprint features. 
+Permutation tests are performed on each discriminant separately so as to retain the interpretation feature: i.e. significant tests can be interpreted in terms of the original fingerprint features.
 <<>>=
-nPerm=100 
-#Only 100 permutations are used 
+nPerm=100
+#Only 100 permutations are used
 #so as to restrict the computational burden when generating the vignette
 disc=1:2 #Test only in the space of first 2 discriminants
 fDa=flowDaTest(fDa,disc=disc,nPerm)
@@ -354,7 +353,7 @@ data(fDa)
 adjustedPvalues=pAdjustMx(getMpc(fDa)$pValuePerm)
 adjustedPvalues
 @
-{Because DA and PCA are both linear projections, significant differences can be interpreted in the original space. 
+{Because DA and PCA are both linear projections, significant differences can be interpreted in the original space.
 Let $\mb{U}$ denote the $p \times U$ loading matrix of the discriminants, $U$ the number of discriminants, and $\mb{M}$ the loading matrix of the first $p$ PCs and $\mb{X}^*$ the centered fingerprint matrix, then an $N\times D$ matrix $\mb{D}$ with DA scores can be calculated by
 \[\mb{D}=\mb{X}^*\mb{MU},\]
 and the contrasts $\mb{C}$ in the DA space by
@@ -368,8 +367,8 @@ with $\mb{L}_l$ the $l^\text{th}$ column of the contrast matrix $\mb{L}$, $\mb{X
 Note, that the $l^\text{th}$ contrast on the $k^\text{th}$ discriminant, $c_{lk}$ consists of the sum of the contributions on all $r$ grid points of the fingerprint, $c_{lk}=\sum_{j=1}^r  c_{ljk}$.
 By plotting the $c_{ljk}$, we can interpret the contributions in terms of the original bivariate estimates on the grid points.
 
-This is illustrated in Figure \ref{figDisc1IntN24-C}  for the contrast between n24 and c-samples on the first discriminant. 
-Note, that in this case the contrast on centered fingerprints and on the original fingerprints will be equal because the average fingerprint used for centering will cancel out. 
+This is illustrated in Figure \ref{figDisc1IntN24-C}  for the contrast between n24 and c-samples on the first discriminant.
+Note, that in this case the contrast on centered fingerprints and on the original fingerprints will be equal because the average fingerprint used for centering will cancel out.
 The interpretation is given in the caption of the plot. }
 \begin{figure}[h!]
 \begin{center}
@@ -391,7 +390,7 @@ contour=TRUE,contourLevel=c(-.04,.04),contourLwd=4)
 \end{figure}
 \clearpage
 
-The significant difference between 24h heat (h24) and control (c) treatment is more subtle. The score on the second discriminant is on average slightly lower for h24 than for c-samples. The interpretation plots show that this corresponds to a shift of the h24 distribution to slightly lower SS and a slightly higher FL1. (Figure \ref{figDisc2IntH24-C}) 
+The significant difference between 24h heat (h24) and control (c) treatment is more subtle. The score on the second discriminant is on average slightly lower for h24 than for c-samples. The interpretation plots show that this corresponds to a shift of the h24 distribution to slightly lower SS and a slightly higher FL1. (Figure \ref{figDisc2IntH24-C})
 \begin{figure}[h!]
 \begin{center}
 <<fig=TRUE, png=TRUE, pdf=FALSE, eps=FALSE>>=
@@ -438,7 +437,7 @@ sampleNames=rownames(getBasis(fbasis))
 #pdf("allBasis.pdf",height=7,width=15)
 #par(mfrow=c(1,3))
 ##cex to enlarge font
-#for (i in 1:nSamp) 
+#for (i in 1:nSamp)
 #plot(fbasis,sample=i,ask=FALSE,main=sampleNames[i],
 #cex.main=1.5,cex.axis=1.5,cex.lab=1.5)
 #dev.off()
@@ -451,7 +450,7 @@ sampleNames=rownames(getBasis(fbasis))
 #uncomment to create a pdf with all average bivariate distributions plots for each group
 #pdf("allGroupBasis.pdf",height=7,width=15)
 #par(mfrow=c(1,3))
-#for (i in 1:nGroup) 
+#for (i in 1:nGroup)
 #plot(fbasis,sample=group==groupLevels[i],ask=FALSE,main=groupLevels[i],
 #cex.main=1.5,cex.axis=1.5,cex.lab=1.5)
 #dev.off()
@@ -461,10 +460,10 @@ sampleNames=rownames(getBasis(fbasis))
 ##############################################
 
 #extract groups involved in contrasts from p value object
-comp=strsplit(rownames(getMpc(fDa)$p),split="-") 
+comp=strsplit(rownames(getMpc(fDa)$p),split="-")
 
 #create all corresponding contrasts
-L=sapply(comp,function(x,group) 
+L=sapply(comp,function(x,group)
 (group==x[1])/sum(group==x[1])-(group==x[2])/sum(group==x[2]),group=group)
 colnames(L)<-rownames(getMpc(fDa)$p)
 
@@ -485,11 +484,11 @@ adjustedPvalues=pAdjustMx(getMpc(fDa)$p)
 #disc=1
 #plot(fDa,fBasis=fbasis,L=L,ask=TRUE,plotType="discCont",disc=disc,contour=TRUE,
 #contourLevel=c(-.04,.04),contourLwd=4,
-#main=paste("\n D", disc," p=",round(adjustedPvalues[,disc],3),sep="")) 
+#main=paste("\n D", disc," p=",round(adjustedPvalues[,disc],3),sep=""))
 #disc=2
 #plot(fDa,fBasis=fbasis,L=L,ask=TRUE,plotType="discCont",disc=disc,contour=TRUE,
 #contourLevel=c(-.04,.04),contourLwd=4,
-#main=paste("\n D", disc," p=",round(adjustedPvalues[,disc],3),sep="")) 
+#main=paste("\n D", disc," p=",round(adjustedPvalues[,disc],3),sep=""))
 
 #uncomment to create a pdf of the discriminant interpretation plots of contrasts
 #pdf("contrastInterpretationPlotsDiscriminant.pdf",height=7,width=15)
@@ -498,11 +497,11 @@ adjustedPvalues=pAdjustMx(getMpc(fDa)$p)
 #plot(fDa,fBasis=fbasis,L=L,ask=FALSE,plotType="discCont",disc=disc,contour=TRUE,
 #contourLevel=c(-.04,.04),contourLwd=4,
 #main=paste("\n D", disc," p=",round(getMpc(fDa)$p[,disc],3),sep=""),
-#cex.main=1.5,cex.axis=1.5,cex.lab=1.5) 
+#cex.main=1.5,cex.axis=1.5,cex.lab=1.5)
 #dev.off()
 @
 \section*{References}
-De Roy, K., Clement, L., Thas, O., Wang, Y., and Boon, N. (2012). Flow cytometry for fast microbial community fingerprinting. Water Research, 46 (3), 907-919. 
+De Roy, K., Clement, L., Thas, O., Wang, Y., and Boon, N. (2012). Flow cytometry for fast microbial community fingerprinting. Water Research, 46 (3), 907-919.
 
 Ellis, B., Haaland, P., Hahne, F., Le Meur, N. and Gopalakrishnan, N. (2009). flowCore: flowCore: Basic structures for flow cytometry data. R package version 1.26.3.
 

--- a/vignettes/flowFDAProbabilityBinning.Rnw
+++ b/vignettes/flowFDAProbabilityBinning.Rnw
@@ -1,6 +1,6 @@
 \documentclass[10pt]{article}
-%\VignetteIndexEntry{Using flowFDA}
-%\VignetteIndexEntry{flowFDA}
+%\VignetteIndexEntry{Using flowFDA with probability binning}
+%\VignetteIndexEntry{flowFDAprobabilitybinning}
  
 
  \usepackage{graphicx}

--- a/vignettes/flowFDAProbabilityBinning.Rnw
+++ b/vignettes/flowFDAProbabilityBinning.Rnw
@@ -1,7 +1,7 @@
 \documentclass[10pt]{article}
 %\VignetteIndexEntry{Using flowFDA with probability binning}
 %\VignetteIndexEntry{flowFDAprobabilitybinning}
- 
+
 
  \usepackage{graphicx}
   \usepackage{subfigure}
@@ -21,7 +21,6 @@
  \usepackage{color}
 \usepackage{epstopdf}
  \usepackage{Sweave}
-   \usepackage[utf8x]{inputenc} 
 \parskip 0.4cm
 \parindent 0cm
 
@@ -55,7 +54,7 @@
 \newcommand{\bsigma}{\mb{\Sigma}}
 \newcommand{\btheta}{\mb{\theta}}
 \newcommand{\bEta}{\mb{\eta}}
-\newcommand{\bbeta}{\mb{\beta}} 
+\newcommand{\bbeta}{\mb{\beta}}
 \newcommand{\balpha}{\mb{\alpha}}
 \newcommand{\bgamma}{\mb{\gamma}}
 \newcommand{\bphi}{\mb{\varphi}}
@@ -68,7 +67,7 @@
 \newcommand{\logit}{\mathrm{logit}}
 \newcommand{\cH}{\mathcal{H}}
 \newcommand{\odds}[1]{\mathrm{odds}\left( #1 \right)}
-%\DeclareMathOperator*{\min}{min} 
+%\DeclareMathOperator*{\min}{min}
 
 
 
@@ -85,17 +84,17 @@
  \maketitle
 \tableofcontents
 \section{Introduction}
-The \texttt{flowFDA} package can be used for analysing flow cytometry (FC) experiments with functional model based clustering, functional principal component analysis, functional discriminant analysis and to compare multivariate flowcytometry fingerprints across treatments. 
+The \texttt{flowFDA} package can be used for analysing flow cytometry (FC) experiments with functional model based clustering, functional principal component analysis, functional discriminant analysis and to compare multivariate flowcytometry fingerprints across treatments.
 
-Flow cytometry (FC) can generate fast fingerprints by characterizing the multivariate distribution of cellular features of single cells. We developed a statistical pipeline for classifying samples and for inferring on distributional changes induced by experimental factors. Our method consists of 1) Creating a quantitative fingerprint from the multivariate distribution, 2) Extracting informative fingerprint features by discriminant analysis, 3) Permutation tests for assessing differences across treatment groups in the reduced feature space and 4) Interpreting these differences in terms of changes in the multivariate FC distribution. 
+Flow cytometry (FC) can generate fast fingerprints by characterizing the multivariate distribution of cellular features of single cells. We developed a statistical pipeline for classifying samples and for inferring on distributional changes induced by experimental factors. Our method consists of 1) Creating a quantitative fingerprint from the multivariate distribution, 2) Extracting informative fingerprint features by discriminant analysis, 3) Permutation tests for assessing differences across treatment groups in the reduced feature space and 4) Interpreting these differences in terms of changes in the multivariate FC distribution.
 
-In this vignette we illustrate the same functionalities as in the  main \texttt{flowFDA} vignette, but we replace the pairwise bivariate kernel density fingerprint by the probability binning fingerprint implemented in the Bioconductor \texttt{flowFP} package (Holyst and Rogers, 2009). 
+In this vignette we illustrate the same functionalities as in the  main \texttt{flowFDA} vignette, but we replace the pairwise bivariate kernel density fingerprint by the probability binning fingerprint implemented in the Bioconductor \texttt{flowFP} package (Holyst and Rogers, 2009).
 In the example data five treatments on bottled Evian water were considered in the experiment: control (c), 3h heat treatment (h3), 24h heat treatment (h24). 3h nutrient treatment (n3) and 24h nutrient treatment (n24). More details on the experiment can be found in the  main \texttt{flowFDA} vignette and in De Roy et al (2012).
 
 \section{Importing Data}
 
-The package builds upon the Bioconductor package  \texttt{flowCore} to import raw flowcytometric data files in R. 
-We first have to load the \texttt{flowFDA} package and read the flowset. For importing the data we refer to the main vignette of \texttt{flowFDA}. Again, we start from the example data that is available in the \texttt{flowFDAExampleData} package. 
+The package builds upon the Bioconductor package  \texttt{flowCore} to import raw flowcytometric data files in R.
+We first have to load the \texttt{flowFDA} package and read the flowset. For importing the data we refer to the main vignette of \texttt{flowFDA}. Again, we start from the example data that is available in the \texttt{flowFDAExampleData} package.
 
 <<CompanionPkg, eval=FALSE>>=
 install.packages("devtools")
@@ -115,20 +114,20 @@ groupLevels=levels(group)
 @
 
 \section{Constructing a flowBasis object using Probability Binning}
-A p-dimensional quantitative fingerprint is derived from the multivariate FCM distribution using the recursive probability binning (PB) algorithm for flow cytometry data that is implemented in the Bioconductor package \texttt{flowFP}. 
-At the first level of the algorithm the population of the cells are divided into two bins. 
-Then, each of the two ``parent'' bins is divided into two ``daughter'' bins, and so forth. 
+A p-dimensional quantitative fingerprint is derived from the multivariate FCM distribution using the recursive probability binning (PB) algorithm for flow cytometry data that is implemented in the Bioconductor package \texttt{flowFP}.
+At the first level of the algorithm the population of the cells are divided into two bins.
+Then, each of the two ``parent'' bins is divided into two ``daughter'' bins, and so forth.
 The final number of bins, $n_\text{bin}$, is determined by the number of recursive subdivisions I, such that $n_\text{bin}=2^I$.
-Note, that the algorithm constructs the bins in such a way that they contain a nearly equal number of cells from the pooled FC sample that were used to build the PB model. This provides an efficient representation of the structure in the multivariate data space by hyper-rectangular regions (bins) of varying size and shape. 
-We pool the data of all samples together for constructing the  PB model. 
-The obtained PB model is then applied to each individual sample, which results in a feature vector of counts for each bin of the model. 
-The bin counts for each sample are normalized by the total number of cells in the sample. 
-The normalized bin counts are also referred to as the fingerprint. 
+Note, that the algorithm constructs the bins in such a way that they contain a nearly equal number of cells from the pooled FC sample that were used to build the PB model. This provides an efficient representation of the structure in the multivariate data space by hyper-rectangular regions (bins) of varying size and shape.
+We pool the data of all samples together for constructing the  PB model.
+The obtained PB model is then applied to each individual sample, which results in a feature vector of counts for each bin of the model.
+The bin counts for each sample are normalized by the total number of cells in the sample.
+The normalized bin counts are also referred to as the fingerprint.
 More details  on the PB algorithm can be found in Roederer et al. (2001).
-Note, that the PB method has to be reconstructed if new samples are available. 
+Note, that the PB method has to be reconstructed if new samples are available.
 Hence, the PB fingerprint for a particular sample depends on the other samples that were analysed, simultaneously.
 This bivariate kernel density fingerprint implemented in the main \texttt{flowFDA} vignette, however, does not depend upon other samples and do not have to be reconstructed when samples are added or removed from the analysis.
-With the PB approach all functionalities and interpretation plots of the \texttt{flowFDA} package can also be used. 
+With the PB approach all functionalities and interpretation plots of the \texttt{flowFDA} package can also be used.
 
 The code below can be used to set up a flowBasis object using a PB fingerprint.
 <<>>=
@@ -139,8 +138,8 @@ fbasisPb
 
 
 \section{Data exploration}
-The PB fingerprints can be explored graphically. An example for third flowset can be generated using the code below. Bivariate projections for the probability binning approach used in De Roy et al. (2012) are given in \ref{figFbasisPb3}. Note, that 
-the bivariate kernel density (KD) approach provides a better interpretation than  the PB approach. The multivariate bins are projected on all bivariate combinations of the flow channels that were used to build the PB model. Hence, they might overlap each other in the projection, which obscures the interpretation. Moreover, each bin was constructed so as to contain approximately an equal amount of cells in the pooled sample used to construct the model. Large bins, thus, coincide with a low density of cells. Hence, low density regions are often overemphasised in the graphs. 
+The PB fingerprints can be explored graphically. An example for third flowset can be generated using the code below. Bivariate projections for the probability binning approach used in De Roy et al. (2012) are given in \ref{figFbasisPb3}. Note, that
+the bivariate kernel density (KD) approach provides a better interpretation than  the PB approach. The multivariate bins are projected on all bivariate combinations of the flow channels that were used to build the PB model. Hence, they might overlap each other in the projection, which obscures the interpretation. Moreover, each bin was constructed so as to contain approximately an equal amount of cells in the pooled sample used to construct the model. Large bins, thus, coincide with a low density of cells. Hence, low density regions are often overemphasised in the graphs.
 \begin{figure}[h!]
 \begin{center}
 <<fig=TRUE, png=TRUE, pdf=FALSE, eps=FALSE>>=
@@ -152,7 +151,7 @@ plot(fbasisPb,ask=FALSE,samples=3)
 \label{figFbasisPb3}
 \end{figure}
 \clearpage
-The fingerprints can also be averaged over several flows, i.e. for the flows belonging to the same group. An example of the graphical interpretation of the averaged fingerprints for the control group (c) and 24h nutrient treatment group (n24) are given in Figure \ref{figFbasisPbCN24h}. 
+The fingerprints can also be averaged over several flows, i.e. for the flows belonging to the same group. An example of the graphical interpretation of the averaged fingerprints for the control group (c) and 24h nutrient treatment group (n24) are given in Figure \ref{figFbasisPbCN24h}.
 \begin{figure}[h!]
 \begin{center}
 <<fig=TRUE, png=TRUE, pdf=FALSE, eps=FALSE>>=
@@ -185,12 +184,12 @@ plot(fbasisPb,L=L,set=which(L!=0),ask=FALSE,main=paste(groupLevels[4],"-",groupL
 \end{figure}
 \clearpage
 
-The fingerprints can also be explored by using principal component analysis and model based clustering. Details on the methods can be found in the main \texttt{flowFDA} vignette. We build upon the \texttt{mclust} package that relies on Gaussian mixture models. The model based clustering in this example is performed by using the first 9 principal components. They capture 95\% of the variability in the original fingerprints. Scores for the first 2 principal components are given in Figure \ref{figPCAbiplot}. 
+The fingerprints can also be explored by using principal component analysis and model based clustering. Details on the methods can be found in the main \texttt{flowFDA} vignette. We build upon the \texttt{mclust} package that relies on Gaussian mixture models. The model based clustering in this example is performed by using the first 9 principal components. They capture 95\% of the variability in the original fingerprints. Scores for the first 2 principal components are given in Figure \ref{figPCAbiplot}.
 <<>>=
 #construct flowPca object with probability binning basis
-fPcaPb=flowPca(fbasisPb) 
+fPcaPb=flowPca(fbasisPb)
 
-#perform model based clustering, 
+#perform model based clustering,
 #use n PCs so as to capture at least 95 % of the variability
 nPca(fPcaPb)<-.95
 nPca(fPcaPb) #number of PCs used for model based clustering
@@ -201,9 +200,9 @@ cbind(as.character(getClustClass(fPcaPb)),as.character(group)) # cluster class l
 \begin{center}
 <<fig=TRUE, png=TRUE, pdf=FALSE, eps=FALSE>>=
 par(mfrow=c(1,2))
-plot(fPcaPb,groups=getClustClass(fPcaPb),main="Prob. Bin. (Clustering)") 
+plot(fPcaPb,groups=getClustClass(fPcaPb),main="Prob. Bin. (Clustering)")
 plot(fPcaPb,groups=group,main="Prob. Bin. (Treatment)")
-legend("topleft",legend=c("c","h24","h3","n24","n3"),pch=1:5,col=1:5) 
+legend("topleft",legend=c("c","h24","h3","n24","n3"),pch=1:5,col=1:5)
 @
 \end{center}
 \caption{Scores for the first two principal components. In the left panel the samples are classified using model based clustering and in the right panel the samples are labelled according to the actual experimental factor.}
@@ -211,7 +210,7 @@ legend("topleft",legend=c("c","h24","h3","n24","n3"),pch=1:5,col=1:5)
 \end{figure}
 \clearpage
 
-The scores on the PC's can be interpreted in terms of the original bivariate distributions. They consist of linear combinations of the contrast between the sample- and average fingerprint over all samples. Some regions will contribute negatively to the PC score and others positively. The colours in the plot indicates the contribution to the PC score, which consists of the sum over all $n_\text{bin}=128$ bins of the PB fingerprint. 
+The scores on the PC's can be interpreted in terms of the original bivariate distributions. They consist of linear combinations of the contrast between the sample- and average fingerprint over all samples. Some regions will contribute negatively to the PC score and others positively. The colours in the plot indicates the contribution to the PC score, which consists of the sum over all $n_\text{bin}=128$ bins of the PB fingerprint.
 The bottom-right panel shows the contrast of the fingerprints along with bin-colours according to their contribution to the PC-scores.
 The interpretation of the score for sample 3 is given in the caption of Figure \ref{figPCAbiplotIntPb}.
 
@@ -231,7 +230,7 @@ intSamples=3 #for the group average of first group set intSamples=which(group=gr
  # interpretation in terms of contrast to average bivariate density
  #contrast between average bivariate density of intSamples vs overall average
 L=rep(-1/nSamp,nSamp)
-L[intSamples]=L[intSamples]+1/length(intSamples) 
+L[intSamples]=L[intSamples]+1/length(intSamples)
 plot(fPcaPb,fBasis=fbasisPb,disc=1,plotType="pcaCont",L=L,ask=FALSE,main="PC 1")
 @
 \end{center}
@@ -243,7 +242,7 @@ plot(fPcaPb,fBasis=fbasisPb,disc=1,plotType="pcaCont",L=L,ask=FALSE,main="PC 1")
 Here, we construct a \texttt{flowDa} object for supervised discrimination method between groups. Again, regularisation is provided by performing PCA first and adopting DA on the first few PC's that explain more that 95\%  of the variability in the fingerprint. In our application this corresponds to 9 PCs. Hence, we reduced the dimensionality of the problem from 128 bin-features to 6. More details on the procedure can be found in the main \texttt{flowFDA} vignette.
 <<>>=
 #####Discriminant analysis for prob. bin.
-fDaPb=flowDa(fbasisPb,groups= group, nPca=.95) 
+fDaPb=flowDa(fbasisPb,groups= group, nPca=.95)
 fDaPb
 @
 
@@ -267,8 +266,8 @@ Pairwise permutation tests are used to assess differences between treatments.  T
 Significant tests can be interpreted in terms of the features of the original fingerprint. More details on the procedure can be found in the main \texttt{flowFDA} vignette.
 
 <<>>=
-nPerm=100 
-#Only 100 permutations are used 
+nPerm=100
+#Only 100 permutations are used
 #so as to restrict the computational burden when generating the vignette
 #nPerm=10000
 disc=1:2 #Test only in the space of first 2 discriminants
@@ -282,7 +281,7 @@ adjustedPvalues=pAdjustMx(getMpc(fDaPb)$pValuePerm)
 adjustedPvalues
 @
 Note, again that the adjusted p-values in this vignette are based on very few permutations to reduce the computational burden.
-Significant differences can be interpreted in the original space. This is illustrated for the first discriminant in Figure \ref{figDisc1IntPbN24-C}. The interpretation is given in the caption of the plot. 
+Significant differences can be interpreted in the original space. This is illustrated for the first discriminant in Figure \ref{figDisc1IntPbN24-C}. The interpretation is given in the caption of the plot.
 
 
 \begin{figure}[h!]
@@ -307,10 +306,10 @@ plot(fDaPb,fBasis=fbasisPb,L=L,ask=FALSE,plotType="discCont",disc=disc)
 
 \section{Generating plots for multiple contrasts}
 Again, plots for multiple contrasts can be generated when using PB fingerprinting. We refer to the main \texttt{flowFDA} vignette for
-detailed code. The flowBasis, flowPca and flowDa object have to be replaced by objects generated with a PB fingerprint basis. 
+detailed code. The flowBasis, flowPca and flowDa object have to be replaced by objects generated with a PB fingerprint basis.
 
 \section*{References}
-De Roy, K., Clement, L., Thas, O., Wang, Y., and Boon, N. (2012). Flow cytometry for fast microbial community fingerprinting. Water Research, 46 (3), 907-919. 
+De Roy, K., Clement, L., Thas, O., Wang, Y., and Boon, N. (2012). Flow cytometry for fast microbial community fingerprinting. Water Research, 46 (3), 907-919.
 
 Ellis, B., Haaland, P., Hahne, F., Le Meur, N. and Gopalakrishnan, N. (2009). flowCore: flowCore: Basic structures for flow cytometry data. R package version 1.26.3.
 


### PR DESCRIPTION
as of R 3.6.0 R CMD check has become more stringent, and was throwing an error in installing due to a typo in flowFdaClasses, which left the prototype of param declared as para::

```
Error in reconcilePropertiesAndPrototype(name, slots, prototype, superClasses,  : 
  The prototype for class "flowBasis" has undefined slot(s): 'para'
Error: unable to load R code in package 'flowFDA'
Execution halted
ERROR: lazy loading failed for package 'flowFDA'
```

This PR fixes that along with a warning that vignettes had the same indexEntry